### PR TITLE
fix: not passing iconPath on linux causing broken dialog

### DIFF
--- a/linux/flutter_platform_alert_plugin.cc
+++ b/linux/flutter_platform_alert_plugin.cc
@@ -258,7 +258,7 @@ static FlMethodResponse *show_custom_alert(FlutterPlatformAlertPlugin *self,
 
   g_autofree gchar *icon_path = get_string_value(args, "iconPath", &error);
 
-  if (icon_path != nullptr) {
+  if (strcmp(icon_path, "") != 0)
     // gtk_message_dialog_set_image is already deprecated but let us just
     // continue use it today.
 #pragma GCC diagnostic push


### PR DESCRIPTION
If no `iconPath` is set from `FlutterPlatformAlert.showCustomAlert`, the string fallbacks to an empty string in the platform channel call. This causes dialog layout to be broken on Linux.

Equivalent Windows implementation checks for an empty string as opposed to a `nullptr`. While current Linux implementation was checking for a nullptr.

https://github.com/zonble/flutter_platform_alert/blob/13a2c28e6dc9b7424b3aa1d92f22d29189ef8b3d/windows/flutter_platform_alert_plugin.cpp#L376

**Before:**

![Screenshot from 2022-07-23 11 39 54](https://user-images.githubusercontent.com/28951144/180593039-80adcd9c-24ec-4a3a-a922-cad6158ae49a.png)

**Now:**

![Screenshot from 2022-07-23 11 42 52](https://user-images.githubusercontent.com/28951144/180593043-d4c57f80-3250-440a-abcf-edb7e8b1a91e.png)

**Equivalent code:**
```dart
final choice = await FlutterPlatformAlert.showCustomAlert(
  windowTitle: 'Update available: v0.2.7',
  text: 'You can\'t skip this one. Can you? 😏',
  positiveButtonTitle: 'Download now',
  negativeButtonTitle: 'Remind me next time',
  neutralButtonTitle: null,
  options: FlutterPlatformAlertOption(
    preferMessageBoxOnWindows: false,
    additionalWindowTitleOnWindows: 'Update',
    showAsLinksOnWindows: true,
  ),
);
```