### PR TITLE
Resolve AGP8 Upgrade Compilation Issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ android {
     }
 
     defaultConfig {
+        namespace "net.zonble.flutter_platform_alert"
         minSdkVersion 19
     }
 }


### PR DESCRIPTION
In this commit, a namespace "net.zonble.flutter_platform_alert" has been added to the `defaultConfig` block in the `android/build.gradle` file. This change is instrumental in resolving a compilation issue encountered during the upgrade to Android Gradle Plugin (AGP) version 8.

Without this implementation, the system throws an error stating "Namespace not specified. Please specify a namespace in the module's build.gradle file like so:". This error emerges due to the absence of a specified namespace in the `build.gradle` file, which is a prerequisite in AGP8 and later versions.

By defining a namespace in the module's `build.gradle` file, this commit ensures the proper functioning of the build process post-upgrade to AGP8, thereby maintaining the application's stability and reliability. This change is critical for the seamless continuation of the build process and is implemented in compliance with the AGP8 requirements.